### PR TITLE
fix: update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,17 +1,12 @@
-Edo platform
+Trinket platform
 ============
-Copyright (C) Sony Mobile Communications 2019
----------------------------------------------
-
-Android device configuration for the edo platform (**SM8250**).
+Android device configuration for the trinket platform (**SM6125**).
 
 ### Supported devices
 
 | Device | Codename |
 |-|:-:|
-| Xperia 1 II | [pdx203](https://github.com/sonyxperiadev/device-sony-pdx203) |
-| Xperia 5 II | [pdx206](https://github.com/sonyxperiadev/device-sony-pdx206) |
-
-### Build instructions
-
-https://developer.sony.com/develop/open-devices/guides/aosp-build-instructions/
+| Moto G Power (2020) | [sofia](https://github.com/moto-common/android_device_motorola_amogus) |
+| Moto g8 Power | [sofiar](https://github.com/moto-common/android_device_motorola_amogus) |
+| Moto G Stylus / G Pro (2020) | [sofiap](https://github.com/moto-common/android_device_motorola_amogus) |
+| Moto g8/G Fast (2020) | [rav](https://github.com/moto-common/android_device_motorola_amogus) |


### PR DESCRIPTION
Been updated device names, their CPU platform; removed unnecessary copyright (it's another manufacturer, which part of this – is from Motorola or Sony?); removed build instructions from Sony (better to do a fresh document for building AOSP (Android Open Source Package) from a scratch, but not rely on building for Sony devices).